### PR TITLE
add version to title

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>discord.js</title>
+  <title>discord.js v11.2.1</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="shortcut icon" type="image/x-icon" href="/static/favicon.ico" />


### PR DESCRIPTION
I think one of the reasons for the confusion with the old docs is that people new to the lib have no idea what the current version is, so for better identification with google search results, we should change the title of the docs to reflect the current stable version.
![image](https://user-images.githubusercontent.com/311745/31360995-105cb294-ad1f-11e7-8494-2ca95c94b51d.png)

Unfortunately macdja continues to refuse to take down his docs so this is probably the best course of action until further notice.
