### PR TITLE
Maintain same page on tag update

### DIFF
--- a/src/components/docs/Navbar.vue
+++ b/src/components/docs/Navbar.vue
@@ -57,7 +57,7 @@
 
       tagChoice(tag) {
         if (tag && this.$route.params.tag !== tag) {
-          this.$router.push({ name: 'docs-tag', params: { source: this.sourceChoice, tag: tag } });
+          this.$router.push({ name: this.$route.name, params: Object.assign(this.$route.params, { tag: tag }) });
         }
       },
 


### PR DESCRIPTION
This will maintain the same page when switching branches. However, if the page does not exist on the branch, it will show the unknown page.

![img](https://puu.sh/ym6ub/762398ba5e.gif)

Edit: Looking for a way to gracefully go back to the main page if the route doesn't exist on the target branch.